### PR TITLE
Update chart suggestion UI copy for single-chart suggestions

### DIFF
--- a/src/features/reports/FileReport/FileReport.tsx
+++ b/src/features/reports/FileReport/FileReport.tsx
@@ -253,7 +253,8 @@ export function FileReport() {
             })),
           );
           notification.success({
-            message: `${suggestions.length} gráfico(s) sugerido(s) adicionado(s). Revise e salve.`,
+            message:
+              "Gráfico sugerido adicionado. Revise e salve — clique novamente para sugerir outro.",
           });
         }
       }

--- a/src/features/reports/FileReport/SuggestChartsButton.tsx
+++ b/src/features/reports/FileReport/SuggestChartsButton.tsx
@@ -26,7 +26,7 @@ export const SuggestChartsButton: React.FC<SuggestChartsButtonProps> = ({
       trigger="click"
       open={open}
       onOpenChange={setOpen}
-      title="Sugerir gráficos"
+      title="Sugerir gráfico"
       content={
         <div style={{ width: 300 }}>
           <Textarea
@@ -40,13 +40,13 @@ export const SuggestChartsButton: React.FC<SuggestChartsButtonProps> = ({
             style={{ marginBottom: "8px" }}
           />
           <Button type="primary" onClick={handleGenerate} block>
-            Gerar sugestões
+            Gerar sugestão
           </Button>
         </div>
       }
     >
       <Button icon={<BulbOutlined />} loading={loading}>
-        Sugerir gráficos
+        Sugerir gráfico
       </Button>
     </Popover>
   );


### PR DESCRIPTION
The backend now suggests one chart per request, so use singular
wording on the suggest button and success toast, and hint that
clicking again suggests another chart.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tw48YHcbF4qrWgJbDBGd3u