### PR TITLE
Add prompt version selection for SOAP note generation

### DIFF
--- a/src/features/clinicalNotes/NavigationSoapNote/NavigationSoapNote.tsx
+++ b/src/features/clinicalNotes/NavigationSoapNote/NavigationSoapNote.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { Alert, Collapse, Empty, Input, Spin } from "antd";
+import { Alert, Collapse, Empty, Input, Segmented, Spin } from "antd";
 import { ReloadOutlined } from "@ant-design/icons";
 import DOMPurify from "dompurify";
 
@@ -100,8 +100,8 @@ export function NavigationSoapNote() {
   }));
 
   const generateNote = useCallback(
-    (id: string) => {
-      dispatch(generateNavigationSoapNote({ id }) as any).then(
+    (id: string, promptKey?: string | null) => {
+      dispatch(generateNavigationSoapNote({ id, promptKey }) as any).then(
         (result: any) => {
           if (result.error) {
             notification.error({ message: getErrorMessage(result, t) });
@@ -182,15 +182,43 @@ export function NavigationSoapNote() {
       }}
       footer={
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-          {generate.status === "succeeded" && (
-            <Button
-              icon={<ReloadOutlined />}
-              onClick={() => note && generateNote(note.id)}
-              style={{ marginRight: "auto" }}
-            >
-              {t("navigationSoapNote.btnRegenerate")}
-            </Button>
-          )}
+          <div
+            style={{
+              marginRight: "auto",
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            {generate.promptOptions.length > 1 && (
+              <Tooltip title={t("navigationSoapNote.promptVersionHint")}>
+                <Segmented
+                  size="small"
+                  value={generate.selectedPromptKey}
+                  options={generate.promptOptions.map(
+                    (option: { key: string; label: string }) => ({
+                      label: option.label,
+                      value: option.key,
+                    }),
+                  )}
+                  disabled={generate.status === "loading" || isSaving}
+                  onChange={(value) =>
+                    note && generateNote(note.id, value as string)
+                  }
+                />
+              </Tooltip>
+            )}
+            {generate.status === "succeeded" && (
+              <Button
+                icon={<ReloadOutlined />}
+                onClick={() =>
+                  note && generateNote(note.id, generate.selectedPromptKey)
+                }
+              >
+                {t("navigationSoapNote.btnRegenerate")}
+              </Button>
+            )}
+          </div>
           <Button onClick={handleClose}>
             {t("navigationSoapNote.btnCancel")}
           </Button>
@@ -279,7 +307,9 @@ export function NavigationSoapNote() {
                 <Button
                   danger
                   icon={<ReloadOutlined />}
-                  onClick={() => note && generateNote(note.id)}
+                  onClick={() =>
+                    note && generateNote(note.id, generate.selectedPromptKey)
+                  }
                 >
                   {t("navigationSoapNote.btnRegenerate")}
                 </Button>

--- a/src/features/clinicalNotes/NavigationSoapNote/NavigationSoapNote.tsx
+++ b/src/features/clinicalNotes/NavigationSoapNote/NavigationSoapNote.tsx
@@ -182,43 +182,17 @@ export function NavigationSoapNote() {
       }}
       footer={
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-          <div
-            style={{
-              marginRight: "auto",
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-            }}
-          >
-            {generate.promptOptions.length > 1 && (
-              <Tooltip title={t("navigationSoapNote.promptVersionHint")}>
-                <Segmented
-                  size="small"
-                  value={generate.selectedPromptKey}
-                  options={generate.promptOptions.map(
-                    (option: { key: string; label: string }) => ({
-                      label: option.label,
-                      value: option.key,
-                    }),
-                  )}
-                  disabled={generate.status === "loading" || isSaving}
-                  onChange={(value) =>
-                    note && generateNote(note.id, value as string)
-                  }
-                />
-              </Tooltip>
-            )}
-            {generate.status === "succeeded" && (
-              <Button
-                icon={<ReloadOutlined />}
-                onClick={() =>
-                  note && generateNote(note.id, generate.selectedPromptKey)
-                }
-              >
-                {t("navigationSoapNote.btnRegenerate")}
-              </Button>
-            )}
-          </div>
+          {generate.status === "succeeded" && (
+            <Button
+              icon={<ReloadOutlined />}
+              onClick={() =>
+                note && generateNote(note.id, generate.selectedPromptKey)
+              }
+              style={{ marginRight: "auto" }}
+            >
+              {t("navigationSoapNote.btnRegenerate")}
+            </Button>
+          )}
           <Button onClick={handleClose}>
             {t("navigationSoapNote.btnCancel")}
           </Button>
@@ -285,9 +259,37 @@ export function NavigationSoapNote() {
             flexDirection: "column",
           }}
         >
-          <h4 style={{ marginTop: 0, marginBottom: 12 }}>
-            {t("navigationSoapNote.generatedTitle")}
-          </h4>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
+              marginBottom: 12,
+            }}
+          >
+            <h4 style={{ margin: 0 }}>
+              {t("navigationSoapNote.generatedTitle")}
+            </h4>
+            {generate.promptOptions.length > 1 && (
+              <Tooltip title={t("navigationSoapNote.promptVersionHint")}>
+                <Segmented
+                  size="small"
+                  value={generate.selectedPromptKey}
+                  options={generate.promptOptions.map(
+                    (option: { key: string; label: string }) => ({
+                      label: option.label,
+                      value: option.key,
+                    }),
+                  )}
+                  disabled={generate.status === "loading" || isSaving}
+                  onChange={(value) =>
+                    note && generateNote(note.id, value as string)
+                  }
+                />
+              </Tooltip>
+            )}
+          </div>
 
           {generate.status === "loading" && (
             <div style={{ textAlign: "center", padding: "48px 0" }}>

--- a/src/features/clinicalNotes/NavigationSoapNote/NavigationSoapNoteSlice.ts
+++ b/src/features/clinicalNotes/NavigationSoapNote/NavigationSoapNoteSlice.ts
@@ -21,12 +21,19 @@ export interface INavigationSoapNoteSaveParams {
   formValues: any;
 }
 
+export interface INavigationSoapNotePromptOption {
+  key: string;
+  label: string;
+}
+
 interface INavigationSoapNoteSlice {
   note: INavigationSoapNoteSource | null;
   generate: {
     status: "idle" | "loading" | "succeeded" | "failed";
     error: string | null;
     text: string;
+    promptOptions: INavigationSoapNotePromptOption[];
+    selectedPromptKey: string | null;
   };
   save: {
     status: "idle" | "loading" | "succeeded" | "failed";
@@ -40,6 +47,8 @@ const initialState: INavigationSoapNoteSlice = {
     status: "idle",
     error: null,
     text: "",
+    promptOptions: [],
+    selectedPromptKey: null,
   },
   save: {
     status: "idle",
@@ -49,9 +58,12 @@ const initialState: INavigationSoapNoteSlice = {
 
 export const generateNavigationSoapNote = createAsyncThunk(
   "navigationSoapNote/generate",
-  async (params: { id: string }, thunkAPI) => {
+  async (params: { id: string; promptKey?: string | null }, thunkAPI) => {
     try {
-      const response = await api.clinicalNotes.generateSoap(params);
+      const response = await api.clinicalNotes.generateSoap({
+        id: params.id,
+        prompt_key: params.promptKey ?? undefined,
+      });
       return response.data;
     } catch (err: any) {
       return thunkAPI.rejectWithValue(err?.response?.data);
@@ -97,6 +109,10 @@ const navigationSoapNoteSlice = createSlice({
       .addCase(generateNavigationSoapNote.fulfilled, (state, action) => {
         state.generate.status = "succeeded";
         state.generate.text = action.payload?.data?.text ?? "";
+        state.generate.promptOptions =
+          action.payload?.data?.prompt_options ?? [];
+        state.generate.selectedPromptKey =
+          action.payload?.data?.prompt_key ?? null;
       })
       .addCase(generateNavigationSoapNote.rejected, (state, action) => {
         state.generate.status = "failed";

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1115,7 +1115,8 @@
     "snippetsTitle": "Available texts",
     "searchPlaceholder": "Search texts...",
     "insertHint": "Click to insert into text",
-    "noResults": "No texts found."
+    "noResults": "No texts found.",
+    "promptVersionHint": "Choose the generated note format"
   },
   "onboarding": {
     "welcome": {

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -1125,7 +1125,8 @@
     "snippetsTitle": "Textos disponíveis",
     "searchPlaceholder": "Buscar textos...",
     "insertHint": "Clique para inserir no texto",
-    "noResults": "Nenhum texto encontrado."
+    "noResults": "Nenhum texto encontrado.",
+    "promptVersionHint": "Escolha o formato da evolução gerada"
   },
   "onboarding": {
     "welcome": {


### PR DESCRIPTION
## Summary
Adds the ability to select different prompt versions when generating clinical SOAP notes. Users can now choose between multiple generated note formats via a segmented control, and regenerate notes using the previously selected prompt version.

## Key Changes
- **UI Enhancement:** Added a `Segmented` control in the generated note section that displays available prompt options when multiple versions exist
- **State Management:** Extended `NavigationSoapNoteSlice` to track:
  - `promptOptions`: Array of available prompt versions with key/label pairs
  - `selectedPromptKey`: Currently selected prompt version
- **API Integration:** Updated `generateNavigationSoapNote` thunk to accept and pass `promptKey` parameter to the backend
- **Regeneration:** Modified regenerate buttons to preserve the selected prompt version when regenerating notes
- **UX Details:**
  - Segmented control is disabled during loading or saving operations
  - Tooltip provides hint text about prompt version selection
  - Control only displays when multiple prompt options are available
- **Translations:** Added `promptVersionHint` translation key in both English and Portuguese

## Implementation Details
- The segmented control is conditionally rendered only when `promptOptions.length > 1`
- Prompt options are populated from the API response payload (`prompt_options` and `prompt_key`)
- The `promptKey` parameter is converted to snake_case (`prompt_key`) when calling the API
- Regenerate buttons now pass `generate.selectedPromptKey` to maintain user's choice across regenerations

https://claude.ai/code/session_01Q4Qw2cTg8JBDYRMm3heziw