### PR TITLE
feat: enviar link de reset de senha pelo Gmail

### DIFF
--- a/src/features/userAdmin/Form/Base.jsx
+++ b/src/features/userAdmin/Form/Base.jsx
@@ -22,7 +22,7 @@ function BaseForm() {
   const dispatch = useDispatch();
   const features = useSelector((state) => state.user.account.features);
   const segments = useSelector((state) => state.segments.list);
-  const { values, errors, setFieldValue } = useFormikContext();
+  const { values, errors, setFieldValue, initialValues } = useFormikContext();
   const [pwLoading, setPWLoading] = useState(false);
   const featureService = FeaturesService(features);
 
@@ -49,8 +49,8 @@ function BaseForm() {
               link={`${
                 import.meta.env.VITE_APP_URL || window.location.origin
               }/reset/${response.payload.data}`}
-              name={values.name}
-              email={values.email}
+              name={initialValues.name}
+              email={initialValues.email}
             />
           ),
           icon: null,

--- a/src/features/userAdmin/Form/Base.jsx
+++ b/src/features/userAdmin/Form/Base.jsx
@@ -4,7 +4,7 @@ import { useFormikContext } from "formik";
 import { useTranslation } from "react-i18next";
 import { Flex, Tabs } from "antd";
 
-import { Input, Select, Textarea, Checkbox } from "components/Inputs";
+import { Input, Select, Checkbox } from "components/Inputs";
 import Switch from "components/Switch";
 import Button from "components/Button";
 import Role from "models/Role";
@@ -14,6 +14,7 @@ import notification from "components/notification";
 import { getUserResetToken } from "features/serverActions/ServerActionsSlice";
 import { getErrorMessage } from "utils/errorHandler";
 import Permission from "models/Permission";
+import { ResetPasswordLink } from "features/userAdmin/ResetPasswordLink/ResetPasswordLink";
 import PermissionService from "services/PermissionService";
 
 function BaseForm() {
@@ -25,11 +26,6 @@ function BaseForm() {
   const [pwLoading, setPWLoading] = useState(false);
   const featureService = FeaturesService(features);
 
-  const copyToClipboard = (text) => {
-    navigator.clipboard.writeText(text);
-    notification.success({ message: "Link copiado!" });
-  };
-
   const generateResetToken = () => {
     setPWLoading(true);
 
@@ -40,30 +36,22 @@ function BaseForm() {
         notification.error({
           message: getErrorMessage(response, t),
         });
+      } else if (!response.payload.data) {
+        notification.error({
+          message:
+            "Não foi possível gerar o link. Verifique se o usuário está ativo.",
+        });
       } else {
         DefaultModal.info({
           title: "Link para Reset de Senha",
           content: (
-            <>
-              <p>
-                Cuidado ao disponibilizar este link. Confira se o usuário é
-                legítimo. Encaminhe este link somente para o email do usuário
-                que irá utilizá-lo.
-              </p>
-              <Textarea
-                onClick={() =>
-                  copyToClipboard(
-                    `${import.meta.env.VITE_APP_URL}/reset/${
-                      response.payload.data
-                    }`,
-                  )
-                }
-                style={{ minHeight: "300px" }}
-                value={`${import.meta.env.VITE_APP_URL}/reset/${
-                  response.payload.data
-                }`}
-              ></Textarea>
-            </>
+            <ResetPasswordLink
+              link={`${
+                import.meta.env.VITE_APP_URL || window.location.origin
+              }/reset/${response.payload.data}`}
+              name={values.name}
+              email={values.email}
+            />
           ),
           icon: null,
           width: 500,

--- a/src/features/userAdmin/ResetPasswordLink/ResetPasswordLink.jsx
+++ b/src/features/userAdmin/ResetPasswordLink/ResetPasswordLink.jsx
@@ -9,9 +9,15 @@ import notification from "components/notification";
 import { getGmailComposeUrl } from "./getGmailComposeUrl";
 
 export const ResetPasswordLink = ({ link, name, email }) => {
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(link);
-    notification.success({ message: "Link copiado!" });
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(link);
+      notification.success({ message: "Link copiado!" });
+    } catch {
+      notification.error({
+        message: "Não foi possível copiar o link. Copie manualmente.",
+      });
+    }
   };
 
   const openGmail = () => {
@@ -28,12 +34,7 @@ export const ResetPasswordLink = ({ link, name, email }) => {
         Cuidado ao disponibilizar este link. Confira se o usuário é legítimo.
         Encaminhe este link somente para o email do usuário que irá utilizá-lo.
       </p>
-      <Textarea
-        onClick={copyToClipboard}
-        style={{ minHeight: "100px" }}
-        value={link}
-        readOnly
-      ></Textarea>
+      <Textarea style={{ minHeight: "100px" }} value={link} readOnly></Textarea>
       <Flex gap="small" style={{ marginTop: "1rem" }}>
         <Button icon={<CopyOutlined />} onClick={copyToClipboard}>
           Copiar link

--- a/src/features/userAdmin/ResetPasswordLink/ResetPasswordLink.jsx
+++ b/src/features/userAdmin/ResetPasswordLink/ResetPasswordLink.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Flex } from "antd";
+import { CopyOutlined, MailOutlined } from "@ant-design/icons";
+
+import { Textarea } from "components/Inputs";
+import Button from "components/Button";
+import notification from "components/notification";
+
+import { getGmailComposeUrl } from "./getGmailComposeUrl";
+
+export const ResetPasswordLink = ({ link, name, email }) => {
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(link);
+    notification.success({ message: "Link copiado!" });
+  };
+
+  const openGmail = () => {
+    window.open(
+      getGmailComposeUrl({ email, name, link }),
+      "_blank",
+      "noopener,noreferrer",
+    );
+  };
+
+  return (
+    <>
+      <p>
+        Cuidado ao disponibilizar este link. Confira se o usuário é legítimo.
+        Encaminhe este link somente para o email do usuário que irá utilizá-lo.
+      </p>
+      <Textarea
+        onClick={copyToClipboard}
+        style={{ minHeight: "100px" }}
+        value={link}
+        readOnly
+      ></Textarea>
+      <Flex gap="small" style={{ marginTop: "1rem" }}>
+        <Button icon={<CopyOutlined />} onClick={copyToClipboard}>
+          Copiar link
+        </Button>
+        <Button
+          type="primary"
+          icon={<MailOutlined />}
+          onClick={openGmail}
+          disabled={!email}
+        >
+          Enviar pelo Gmail
+        </Button>
+      </Flex>
+      {!email && (
+        <p style={{ marginTop: "0.5rem" }}>
+          Este usuário não possui email cadastrado, por isso não é possível
+          preparar o email automaticamente.
+        </p>
+      )}
+    </>
+  );
+};

--- a/src/features/userAdmin/ResetPasswordLink/getGmailComposeUrl.js
+++ b/src/features/userAdmin/ResetPasswordLink/getGmailComposeUrl.js
@@ -1,0 +1,30 @@
+const GMAIL_COMPOSE_URL = "https://mail.google.com/mail/?view=cm&fs=1";
+
+const getFirstName = (name) => (name || "").trim().split(" ")[0];
+
+const getEmailSubject = () => "NoHarm: link para cadastrar uma nova senha";
+
+const getEmailBody = (name, link) =>
+  `Olá, ${getFirstName(name)}!
+
+Segue o link para você cadastrar uma nova senha de acesso à NoHarm:
+
+${link}
+
+Atenção:
+- O link é válido por 6 horas e pode ser utilizado uma única vez.
+- A senha deve ter no mínimo 8 caracteres, com letras maiúsculas, minúsculas e números.
+
+Se o link expirar, responda este email que geramos um novo.
+
+Equipe NoHarm`;
+
+export const getGmailComposeUrl = ({ email, name, link }) => {
+  const params = new URLSearchParams({
+    to: email || "",
+    su: getEmailSubject(),
+    body: getEmailBody(name, link),
+  });
+
+  return `${GMAIL_COMPOSE_URL}&${params.toString()}`;
+};

--- a/src/features/userAdmin/ResetPasswordLink/getGmailComposeUrl.js
+++ b/src/features/userAdmin/ResetPasswordLink/getGmailComposeUrl.js
@@ -1,11 +1,17 @@
+import { passwordValidation } from "utils";
+
 const GMAIL_COMPOSE_URL = "https://mail.google.com/mail/?view=cm&fs=1";
 
-const getFirstName = (name) => (name || "").trim().split(" ")[0];
+const getGreeting = (name) => {
+  const firstName = (name || "").trim().split(" ")[0];
+
+  return firstName ? `Olá, ${firstName}!` : "Olá!";
+};
 
 const getEmailSubject = () => "NoHarm: link para cadastrar uma nova senha";
 
 const getEmailBody = (name, link) =>
-  `Olá, ${getFirstName(name)}!
+  `${getGreeting(name)}
 
 Segue o link para você cadastrar uma nova senha de acesso à NoHarm:
 
@@ -13,7 +19,7 @@ ${link}
 
 Atenção:
 - O link é válido por 6 horas e pode ser utilizado uma única vez.
-- A senha deve ter no mínimo 8 caracteres, com letras maiúsculas, minúsculas e números.
+- ${passwordValidation.message}.
 
 Se o link expirar, responda este email que geramos um novo.
 


### PR DESCRIPTION
## Contexto

Links de reset de senha enviados pelo SES da AWS acabam caindo no spam, então o analista precisa encaminhar o link pelo próprio email. Hoje o modal de **Gerar link para reset de senha** (permissão `ADMIN_USERS`) só mostra o link para copiar manualmente.

## O que muda

No modal, além de copiar o link, agora tem o botão **Enviar pelo Gmail**, que abre o compose do Gmail em nova aba já preenchido com:

- **Para**: email do usuário do formulário
- **Assunto**: `NoHarm: link para cadastrar uma nova senha`
- **Corpo**: saudação com o primeiro nome, o link, aviso de validade (6h, uso único) e os requisitos de senha (mín. 8 caracteres, maiúsculas, minúsculas e números)

O aviso de "confira se o usuário é legítimo" continua no modal, e o botão fica desabilitado se o usuário não tiver email cadastrado.

Junto vão dois ajustes pequenos no mesmo fluxo:

- Se a API devolver token vazio (acontece com usuário inativo, `get_reset_token` filtra `User.active == True`), mostra erro em vez de montar um link terminando em `null`.
- `VITE_APP_URL` só é injetada no build de produção; nos ambientes dev/test o link saía como `undefined/reset/...`. Agora cai em `window.location.origin` quando a variável não existe.

O conteúdo do modal saiu de `Form/Base.jsx` para `features/userAdmin/ResetPasswordLink/`, com a montagem da URL do Gmail isolada em `getGmailComposeUrl.js`.

## Testes

- `npm run lint` — 0 errors
- `npm run build` — os erros de TS que aparecem são pré-existentes na develop (`SupportFormAI/*` e `vite.config.ts`), nenhum nos arquivos deste PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)