### PR TITLE
feat: copiar gráficos de outro relatório customizado

### DIFF
--- a/src/components/ChartCreator/chartRemap.ts
+++ b/src/components/ChartCreator/chartRemap.ts
@@ -1,0 +1,286 @@
+/**
+ * Reconciliation of charts copied from another report.
+ *
+ * A chart references its report's columns by name, so charts copied from a
+ * different report (possibly from another schema) only render if every
+ * referenced column also exists in the destination dataset. These helpers find
+ * the referenced columns, report which ones are missing, and rewrite a chart
+ * onto the destination columns once the user has mapped them.
+ */
+
+import type { ColumnSchema, Filter } from "src/utils/dataFilters";
+import { exprToTokens, tokensToExpr, validateExpr } from "./expression/exprEngine";
+import type { ChartConfig } from "./types";
+
+/** yKeys sentinel meaning "row count"; it is not a column and is never mapped. */
+export const COUNT_KEY = "__count__";
+
+/** Destination column chosen for a missing source column; null means "skip". */
+export type ColumnMapping = Record<string, string | null>;
+
+export interface ChartCopyAnalysis {
+  chart: ChartConfig;
+  /** Every destination column the chart needs, deduplicated. */
+  referenced: string[];
+  /** The referenced columns absent from the destination dataset. */
+  missing: string[];
+  /**
+   * An expression series that no longer parses. Such a chart cannot be rewritten
+   * onto other columns, so it can only be left out of the copy.
+   */
+  exprParseError: boolean;
+}
+
+const generateId = () => Math.random().toString(36).substring(2, 11);
+
+/** Columns referenced by a chart, plus whether one of its expressions is broken. */
+export function collectReferencedColumns(chart: ChartConfig): {
+  columns: string[];
+  exprParseError: boolean;
+} {
+  const columns = new Set<string>();
+  let exprParseError = false;
+
+  (chart.xKeys ?? []).forEach((key) => {
+    if (key) columns.add(key);
+  });
+
+  (chart.yKeys ?? []).forEach((key) => {
+    if (key && key !== COUNT_KEY) columns.add(key);
+  });
+
+  (chart.filters ?? []).forEach((filter) => {
+    if (filter.field) columns.add(filter.field);
+  });
+
+  (chart.series ?? []).forEach((serie) => {
+    const tokens = exprToTokens(serie.expr);
+
+    if (!tokens) {
+      exprParseError = true;
+      return;
+    }
+
+    tokens.forEach((token) => {
+      if (token.kind === "agg" && token.column) columns.add(token.column);
+    });
+  });
+
+  return { columns: Array.from(columns), exprParseError };
+}
+
+/** Classifies each chart against the destination columns. */
+export function classifyCharts(
+  charts: ChartConfig[],
+  targetKeys: string[],
+): ChartCopyAnalysis[] {
+  const available = new Set(targetKeys);
+
+  return charts.map((chart) => {
+    const { columns, exprParseError } = collectReferencedColumns(chart);
+
+    return {
+      chart,
+      referenced: columns,
+      missing: columns.filter((column) => !available.has(column)),
+      exprParseError,
+    };
+  });
+}
+
+/** Applies the mapping to a column: unmapped columns are kept as they are. */
+const mapColumn = (
+  column: string,
+  mapping: ColumnMapping,
+): string | null => {
+  if (!(column in mapping)) return column;
+  return mapping[column];
+};
+
+const mapKeys = (keys: string[], mapping: ColumnMapping): string[] => {
+  const mapped = keys
+    .map((key) => (key === COUNT_KEY ? key : mapColumn(key, mapping)))
+    .filter((key): key is string => !!key);
+
+  return Array.from(new Set(mapped));
+};
+
+const mapFilters = (
+  filters: Filter[],
+  mapping: ColumnMapping,
+  targetSchema: ColumnSchema[],
+): Filter[] => {
+  const byKey = new Map(targetSchema.map((column) => [column.key, column]));
+
+  return filters.reduce<Filter[]>((kept, filter) => {
+    const field = mapColumn(filter.field, mapping);
+    if (!field) return kept;
+
+    const column = byKey.get(field);
+    if (!column) return kept;
+
+    // A filter carried over to a different column keeps only the values that
+    // column actually has; a filter left with no values would hide every row.
+    if (field !== filter.field && Array.isArray(filter.value)) {
+      const options = new Set(column.options ?? []);
+      const value = filter.value.filter((item: any) => options.has(String(item)));
+
+      if (value.length === 0) return kept;
+
+      return [...kept, { ...filter, id: generateId(), field, value }];
+    }
+
+    return [...kept, { ...filter, id: generateId(), field }];
+  }, []);
+};
+
+/**
+ * Rewrites the columns of an expression through the mapping. Serialization
+ * re-quotes column names, so names containing spaces survive the round trip.
+ * Returns null when the expression cannot be parsed or a column was skipped.
+ */
+const mapExpr = (expr: string, mapping: ColumnMapping): string | null => {
+  const tokens = exprToTokens(expr);
+  if (!tokens) return null;
+
+  const mapped = [];
+
+  for (const token of tokens) {
+    if (token.kind !== "agg" || !token.column) {
+      mapped.push(token);
+      continue;
+    }
+
+    const column = mapColumn(token.column, mapping);
+    if (!column) return null;
+
+    mapped.push({ ...token, column });
+  }
+
+  return tokensToExpr(mapped);
+};
+
+const mapColorKeys = (
+  colors: Record<string, string>,
+  mapping: ColumnMapping,
+  seriesIds: Record<string, string>,
+): Record<string, string> =>
+  Object.entries(colors).reduce<Record<string, string>>(
+    (kept, [key, color]) => {
+      if (key === COUNT_KEY) return { ...kept, [key]: color };
+
+      // A series key is either a series id or a column name.
+      const mapped = seriesIds[key] ?? mapColumn(key, mapping);
+      if (!mapped) return kept;
+
+      return { ...kept, [mapped]: color };
+    },
+    {},
+  );
+
+/** Appends "(cópia)" until the title no longer collides with an existing one. */
+const uniqueTitle = (title: string, taken: string[]): string => {
+  if (!taken.includes(title)) return title;
+
+  const candidate = `${title} (cópia)`;
+  if (!taken.includes(candidate)) return candidate;
+
+  let counter = 2;
+  while (taken.includes(`${title} (cópia ${counter})`)) counter += 1;
+
+  return `${title} (cópia ${counter})`;
+};
+
+/** Defaults of a chart config, shared by imported and agent-generated charts. */
+export function withChartDefaults(chart: ChartConfig): ChartConfig {
+  return {
+    aggregation: "none",
+    sortOrder: "none",
+    xSortOrder: "none",
+    xLabelRotate: 0,
+    topN: 0,
+    showLabels: false,
+    height: 400,
+    dateGrouping: "none",
+    showTitle: true,
+    colorPalette: "default",
+    colorMode: "palette",
+    stacked: false,
+    filters: [],
+    ...chart,
+    id: generateId(),
+    // Series may arrive without ids; the builder and the renderer key each
+    // series by id, so ensure every one has a stable id of its own.
+    ...(chart.series
+      ? {
+          series: chart.series.map((serie) => ({
+            ...serie,
+            id: serie.id || generateId(),
+          })),
+        }
+      : {}),
+  };
+}
+
+/**
+ * Rewrites a copied chart onto the destination report.
+ *
+ * Returns null when the chart cannot be represented there: an expression that
+ * does not parse, or one whose column the user chose to skip.
+ */
+export function remapChart(
+  chart: ChartConfig,
+  mapping: ColumnMapping,
+  targetSchema: ColumnSchema[],
+  existingTitles: string[],
+): ChartConfig | null {
+  const remapped = withChartDefaults(chart);
+
+  // A copy keeps nothing from the source report's identity space, so series get
+  // fresh ids and the color keys pointing at them follow.
+  const seriesIds: Record<string, string> = {};
+
+  if (remapped.series) {
+    const series = [];
+
+    for (const serie of remapped.series) {
+      const expr = mapExpr(serie.expr, mapping);
+      if (expr === null) return null;
+
+      const validation = validateExpr(expr, targetSchema);
+      if (!validation.ok) return null;
+
+      const id = generateId();
+      seriesIds[serie.id] = id;
+
+      series.push({ ...serie, id, expr });
+    }
+
+    remapped.series = series;
+  }
+
+  remapped.xKeys = mapKeys(chart.xKeys ?? [], mapping);
+  remapped.yKeys = mapKeys(chart.yKeys ?? [], mapping);
+
+  // Without an X axis there is nothing to plot; a chart with no value series
+  // falls back to counting rows, which stays valid.
+  if (remapped.xKeys.length === 0) return null;
+
+  remapped.filters = mapFilters(chart.filters ?? [], mapping, targetSchema);
+
+  if (remapped.seriesColors) {
+    remapped.seriesColors = mapColorKeys(
+      remapped.seriesColors,
+      mapping,
+      seriesIds,
+    );
+  }
+
+  // Category colors are keyed by data values of the source dataset, which say
+  // nothing about the destination one.
+  delete remapped.categoryColors;
+
+  remapped.title = uniqueTitle(chart.title ?? "", existingTitles);
+
+  return remapped;
+}

--- a/src/components/ChartCreator/chartRemap.ts
+++ b/src/components/ChartCreator/chartRemap.ts
@@ -262,9 +262,10 @@ export function remapChart(
   remapped.xKeys = mapKeys(chart.xKeys ?? [], mapping);
   remapped.yKeys = mapKeys(chart.yKeys ?? [], mapping);
 
-  // Without an X axis there is nothing to plot; a chart with no value series
-  // falls back to counting rows, which stays valid.
-  if (remapped.xKeys.length === 0) return null;
+  // The gauge is a single scalar and has no X axis; for every other type an
+  // empty one leaves nothing to plot. A chart with no value series falls back
+  // to counting rows, which stays valid.
+  if (remapped.type !== "gauge" && remapped.xKeys.length === 0) return null;
 
   remapped.filters = mapFilters(chart.filters ?? [], mapping, targetSchema);
 

--- a/src/features/reports/FileReport/CopyCharts/CopyCharts.tsx
+++ b/src/features/reports/FileReport/CopyCharts/CopyCharts.tsx
@@ -1,0 +1,533 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Empty,
+  Select,
+  Space,
+  Spin,
+  Steps,
+  Table,
+  Tag,
+  notification,
+} from "antd";
+import { useTranslation } from "react-i18next";
+
+import Button from "src/components/Button";
+import Modal from "src/components/Modal";
+import { useAppDispatch } from "src/store";
+import Permission from "src/models/Permission";
+import PermissionService from "src/services/PermissionService";
+import { getErrorMessage } from "src/utils/errorHandler";
+import { fetchSwitchSchemaData } from "src/features/switchSchema/SwitchSchemaSlice";
+import {
+  getCopySourceGraphs,
+  getCopySourceReports,
+} from "src/features/reports/ReportsSlice";
+import {
+  ChartCopyAnalysis,
+  ColumnMapping,
+  classifyCharts,
+  remapChart,
+} from "src/components/ChartCreator/chartRemap";
+import type { ChartConfig } from "src/components/ChartCreator/types";
+import type { ColumnSchema } from "src/utils/dataFilters";
+
+interface CopySourceReport {
+  id: number;
+  name: string;
+  description: string;
+  processedAt: string | null;
+  graphCount: number;
+}
+
+interface CopyChartsProps {
+  open: boolean;
+  onClose: () => void;
+  /** Columns of the report the charts are copied into. */
+  targetSchema: ColumnSchema[];
+  /** Titles already in use, so a copy never duplicates one. */
+  existingTitles: string[];
+  currentSchemaName: string;
+  onImport: (charts: ChartConfig[], summary: CopySummary) => void;
+}
+
+export interface CopySummary {
+  sourceSchema: string;
+  sourceReportId: number;
+  importedCount: number;
+  excludedCount: number;
+  mappedColumnCount: number;
+}
+
+/** Marker for "leave this column behind" in the mapping select. */
+const SKIP = "__skip__";
+
+export function CopyCharts({
+  open,
+  onClose,
+  targetSchema,
+  existingTitles,
+  currentSchemaName,
+  onImport,
+}: CopyChartsProps) {
+  const dispatch = useAppDispatch();
+  const { t } = useTranslation();
+  const canPickSchema = PermissionService().has(Permission.MAINTAINER);
+
+  const [stepIndex, setStepIndex] = useState(0);
+  const [schemas, setSchemas] = useState<string[]>([]);
+  const [sourceSchema, setSourceSchema] = useState(currentSchemaName);
+  const [reports, setReports] = useState<CopySourceReport[]>([]);
+  const [sourceReportId, setSourceReportId] = useState<number | null>(null);
+  const [sourceCharts, setSourceCharts] = useState<ChartConfig[]>([]);
+  const [mapping, setMapping] = useState<ColumnMapping>({});
+  const [excluded, setExcluded] = useState<string[]>([]);
+  const [isLoadingReports, setIsLoadingReports] = useState(false);
+  const [isLoadingCharts, setIsLoadingCharts] = useState(false);
+
+  const targetKeys = useMemo(
+    () => targetSchema.map((column) => column.key),
+    [targetSchema],
+  );
+
+  const resetSource = () => {
+    setSourceReportId(null);
+    setSourceCharts([]);
+    setMapping({});
+    setExcluded([]);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+
+    setStepIndex(0);
+    setSourceSchema(currentSchemaName);
+    resetSource();
+
+    if (canPickSchema) {
+      dispatch(fetchSwitchSchemaData({})).then((response: any) => {
+        if (response.error) return;
+
+        const list = response.payload?.data?.data?.schemas ?? [];
+        setSchemas(list.map((schema: any) => schema.name));
+      });
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!open) return;
+
+    resetSource();
+    setIsLoadingReports(true);
+
+    dispatch(
+      // @ts-expect-error legacy code
+      getCopySourceReports({ sourceSchema }),
+    ).then((response: any) => {
+      setIsLoadingReports(false);
+
+      if (response.error) {
+        setReports([]);
+        notifyError(response);
+        return;
+      }
+
+      setReports(response.payload?.data?.data ?? []);
+    });
+  }, [open, sourceSchema]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const notifyError = (response: any) => {
+    notification.error({ message: getErrorMessage(response, t) });
+  };
+
+  const loadCharts = (idReport: number) => {
+    setSourceReportId(idReport);
+    setSourceCharts([]);
+    setMapping({});
+    setExcluded([]);
+    setIsLoadingCharts(true);
+
+    dispatch(
+      // @ts-expect-error legacy code
+      getCopySourceGraphs({ idReport, sourceSchema }),
+    ).then(
+      (response: any) => {
+        setIsLoadingCharts(false);
+
+        if (response.error) {
+          notifyError(response);
+          return;
+        }
+
+        setSourceCharts(response.payload?.data?.data?.graphs ?? []);
+      },
+    );
+  };
+
+  const analyses = useMemo(
+    () => classifyCharts(sourceCharts, targetKeys),
+    [sourceCharts, targetKeys],
+  );
+
+  const isExcluded = (analysis: ChartCopyAnalysis) =>
+    analysis.exprParseError || excluded.includes(analysis.chart.id);
+
+  const included = analyses.filter((analysis) => !isExcluded(analysis));
+
+  // Only the columns still needed by a chart the user is actually importing.
+  const missingColumns = useMemo(
+    () =>
+      Array.from(
+        new Set(included.flatMap((analysis) => analysis.missing)),
+      ).sort(),
+    [included],
+  );
+
+  const isMapped = (column: string) => column in mapping;
+
+  const pendingColumns = missingColumns.filter((column) => !isMapped(column));
+
+  const mappedColumnCount = missingColumns.filter(
+    (column) => mapping[column],
+  ).length;
+
+  /** Suggests destination columns, exact-ish name matches first. */
+  const candidatesFor = (column: string) => {
+    const normalize = (value: string) =>
+      value
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, "");
+
+    const wanted = normalize(column);
+
+    return [...targetSchema]
+      .sort((a, b) => {
+        const scoreOf = (candidate: ColumnSchema) => {
+          const key = normalize(candidate.key);
+          if (key === wanted) return 0;
+          if (key.includes(wanted) || wanted.includes(key)) return 1;
+          return 2;
+        };
+
+        return scoreOf(a) - scoreOf(b) || a.key.localeCompare(b.key);
+      })
+      .map((candidate) => ({
+        label: `${candidate.key} (${candidate.type})`,
+        value: candidate.key,
+      }));
+  };
+
+  const importable = useMemo(() => {
+    const titles = [...existingTitles];
+
+    return included.reduce<ChartConfig[]>((charts, analysis) => {
+      const chart = remapChart(analysis.chart, mapping, targetSchema, titles);
+      if (!chart) return charts;
+
+      titles.push(chart.title);
+      return [...charts, chart];
+    }, []);
+  }, [included, mapping, targetSchema, existingTitles]);
+
+  const handleImport = () => {
+    onImport(importable, {
+      sourceSchema,
+      sourceReportId: sourceReportId!,
+      importedCount: importable.length,
+      excludedCount: sourceCharts.length - importable.length,
+      mappedColumnCount,
+    });
+    onClose();
+  };
+
+  const selectedReport = reports.find((report) => report.id === sourceReportId);
+
+  const originStep = (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      {canPickSchema && (
+        <div data-testid="copy-source-schema">
+          <div className="modal-section-title">Schema de origem</div>
+          <Select
+            style={{ width: "100%" }}
+            value={sourceSchema}
+            onChange={setSourceSchema}
+            showSearch
+            optionFilterProp="label"
+            options={(schemas.length > 0 ? schemas : [currentSchemaName]).map(
+              (schema) => ({
+                label:
+                  schema === currentSchemaName ? `${schema} (atual)` : schema,
+                value: schema,
+              }),
+            )}
+          />
+        </div>
+      )}
+
+      <div data-testid="copy-source-report">
+        <div className="modal-section-title">Relatório de origem</div>
+        <Select
+          style={{ width: "100%" }}
+          value={sourceReportId}
+          onChange={loadCharts}
+          loading={isLoadingReports}
+          placeholder="Selecione o relatório de onde copiar os gráficos"
+          showSearch
+          optionFilterProp="label"
+          notFoundContent={
+            isLoadingReports ? <Spin size="small" /> : "Nenhum relatório"
+          }
+          options={reports.map((report) => ({
+            label: `${report.name} — ${report.graphCount} gráfico(s)`,
+            value: report.id,
+            disabled: report.graphCount === 0,
+          }))}
+        />
+      </div>
+
+      {selectedReport && !selectedReport.processedAt && (
+        <Alert
+          type="warning"
+          showIcon
+          message="Este relatório ainda não foi processado. Os gráficos podem referenciar colunas que não existem mais."
+        />
+      )}
+
+      {isLoadingCharts && <Spin />}
+
+      {sourceReportId && !isLoadingCharts && sourceCharts.length === 0 && (
+        <Empty description="Este relatório não tem gráficos para copiar." />
+      )}
+    </Space>
+  );
+
+  const columnsStep = (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      {missingColumns.length === 0 ? (
+        <Alert
+          type="success"
+          showIcon
+          message="Todas as colunas usadas pelos gráficos existem neste relatório."
+        />
+      ) : (
+        <div>
+          <div className="modal-section-title">
+            Colunas sem equivalente neste relatório
+          </div>
+          <Table
+            size="small"
+            pagination={false}
+            rowKey={(row: any) => row.column}
+            dataSource={missingColumns.map((column) => ({ column }))}
+            columns={[
+              {
+                title: "Coluna de origem",
+                dataIndex: "column",
+                width: "40%",
+              },
+              {
+                title: "Coluna de destino",
+                render: (_: any, row: any) => (
+                  <Select
+                    style={{ width: "100%" }}
+                    value={
+                      isMapped(row.column)
+                        ? (mapping[row.column] ?? SKIP)
+                        : undefined
+                    }
+                    onChange={(value) =>
+                      setMapping((current) => ({
+                        ...current,
+                        [row.column]: value === SKIP ? null : value,
+                      }))
+                    }
+                    placeholder="Escolha a coluna equivalente"
+                    showSearch
+                    optionFilterProp="label"
+                    options={[
+                      {
+                        label: "Ignorar (remove os gráficos afetados)",
+                        value: SKIP,
+                      },
+                      ...candidatesFor(row.column),
+                    ]}
+                  />
+                ),
+              },
+            ]}
+          />
+        </div>
+      )}
+
+      <div>
+        <div className="modal-section-title">Gráficos</div>
+        <Table
+          size="small"
+          pagination={false}
+          rowKey={(analysis: ChartCopyAnalysis) => analysis.chart.id}
+          dataSource={analyses}
+          rowSelection={{
+            selectedRowKeys: included.map((analysis) => analysis.chart.id),
+            onChange: (keys) =>
+              setExcluded(
+                analyses
+                  .filter((analysis) => !keys.includes(analysis.chart.id))
+                  .map((analysis) => analysis.chart.id),
+              ),
+            getCheckboxProps: (analysis: ChartCopyAnalysis) => ({
+              disabled: analysis.exprParseError,
+            }),
+          }}
+          columns={[
+            {
+              title: "Título",
+              render: (_: any, analysis: ChartCopyAnalysis) =>
+                analysis.chart.title || "(sem título)",
+            },
+            {
+              title: "Situação",
+              width: "45%",
+              render: (_: any, analysis: ChartCopyAnalysis) => {
+                if (analysis.exprParseError) {
+                  return <Tag color="error">Fórmula inválida — não copiável</Tag>;
+                }
+
+                if (isExcluded(analysis)) {
+                  return <Tag>Fora da cópia</Tag>;
+                }
+
+                const pending = analysis.missing.filter(
+                  (column) => !isMapped(column),
+                );
+
+                if (pending.length > 0) {
+                  return (
+                    <Tag color="warning">
+                      Aguardando: {pending.join(", ")}
+                    </Tag>
+                  );
+                }
+
+                const dropped = analysis.missing.filter(
+                  (column) => !mapping[column],
+                );
+
+                if (dropped.length > 0) {
+                  return (
+                    <Tag color="default">
+                      Será removido: {dropped.join(", ")} ignorada(s)
+                    </Tag>
+                  );
+                }
+
+                return <Tag color="success">Pronto</Tag>;
+              },
+            },
+          ]}
+        />
+      </div>
+    </Space>
+  );
+
+  const reviewStep = (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      <Alert
+        type={importable.length > 0 ? "info" : "warning"}
+        showIcon
+        message={`${importable.length} gráfico(s) serão copiados; ${
+          sourceCharts.length - importable.length
+        } ficarão de fora.`}
+        description={
+          mappedColumnCount > 0
+            ? `${mappedColumnCount} coluna(s) foram reaproveitadas em colunas deste relatório.`
+            : undefined
+        }
+      />
+
+      {importable.length > 0 && (
+        <Table
+          size="small"
+          pagination={false}
+          rowKey={(chart: ChartConfig) => chart.id}
+          dataSource={importable}
+          columns={[
+            { title: "Título", dataIndex: "title" },
+            { title: "Tipo", dataIndex: "type", width: 120 },
+          ]}
+        />
+      )}
+
+      <Alert
+        type="info"
+        showIcon
+        message="Os gráficos são adicionados aos existentes. Use o botão salvar para gravá-los."
+      />
+    </Space>
+  );
+
+  const steps = [
+    { title: "Origem", content: originStep, valid: sourceCharts.length > 0 },
+    {
+      title: "Colunas",
+      content: columnsStep,
+      valid: pendingColumns.length === 0 && importable.length > 0,
+    },
+    { title: "Revisão", content: reviewStep, valid: importable.length > 0 },
+  ];
+
+  const isLast = stepIndex === steps.length - 1;
+  const current = steps[stepIndex];
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      title="Copiar gráficos de outro relatório"
+      width={900}
+      destroyOnHidden
+      footer={[
+        <Button key="cancel" onClick={onClose}>
+          Cancelar
+        </Button>,
+        <Button
+          key="back"
+          disabled={stepIndex === 0}
+          onClick={() => setStepIndex((index) => index - 1)}
+        >
+          Voltar
+        </Button>,
+        isLast ? (
+          <Button
+            key="import"
+            type="primary"
+            disabled={!current.valid}
+            onClick={handleImport}
+          >
+            Copiar {importable.length} gráfico(s)
+          </Button>
+        ) : (
+          <Button
+            key="next"
+            type="primary"
+            disabled={!current.valid}
+            onClick={() => setStepIndex((index) => index + 1)}
+          >
+            Próximo
+          </Button>
+        ),
+      ]}
+    >
+      <Steps
+        size="small"
+        current={stepIndex}
+        items={steps.map((step) => ({ title: step.title }))}
+        style={{ margin: "16px 0 24px" }}
+      />
+      <div style={{ maxHeight: "60vh", overflowY: "auto" }}>
+        {current.content}
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/reports/FileReport/FileReport.tsx
+++ b/src/features/reports/FileReport/FileReport.tsx
@@ -13,9 +13,10 @@ import {
   SaveOutlined,
   TableOutlined,
   BarChartOutlined,
+  CopyOutlined,
 } from "@ant-design/icons";
 
-import { useAppDispatch } from "src/store";
+import { useAppDispatch, useAppSelector } from "src/store";
 import { DataViewer } from "src/components/DataViewer/DataViewer";
 import { formatDate } from "src/utils/date";
 import { getFileReport } from "../ReportsSlice";
@@ -54,6 +55,8 @@ import {
 } from "./FileReport.utils";
 import { FilterRow } from "./FilterRow";
 import { ErrorBoundary } from "react-error-boundary";
+import { withChartDefaults } from "src/components/ChartCreator/chartRemap";
+import { CopyCharts, CopySummary } from "./CopyCharts/CopyCharts";
 
 const ChartCreatorFallback = ({
   resetErrorBoundary,
@@ -90,7 +93,11 @@ export function FileReport() {
   const [initialCharts, setInitialCharts] = useState<ChartConfig[]>([]);
   const [currentCharts, setCurrentCharts] = useState<ChartConfig[]>([]);
   const [isSavingCharts, setIsSavingCharts] = useState(false);
+  const [showCopyCharts, setShowCopyCharts] = useState(false);
   const chartCreatorRef = useRef<ChartCreatorHandle>(null);
+  const currentSchema = useAppSelector(
+    (state: any) => state.user.account.schema,
+  );
   const canWriteGraphs = PermissionService().has(
     Permission.WRITE_CUSTOM_REPORTS_GRAPHS,
   );
@@ -207,8 +214,7 @@ export function FileReport() {
 
   // Core suggestion request, reused by both the bulk button and the wizard's
   // per-chart "Gerar com agente" step. Returns normalized ChartConfigs (or
-  // throws on error). Defaults are applied first so a backend-provided `series`
-  // (expression charts) is preserved by the trailing `...chart` spread.
+  // throws on error).
   const requestChartSuggestions = async (
     hint: string,
   ): Promise<ChartConfig[]> => {
@@ -244,28 +250,15 @@ export function FileReport() {
     }
 
     const suggestions: ChartConfig[] = response.payload.data.data ?? [];
-    return suggestions.map((chart) => ({
-      aggregation: "none",
-      sortOrder: "none",
-      xSortOrder: "none",
-      xLabelRotate: 0,
-      topN: 0,
-      showLabels: false,
-      height: 400,
-      dateGrouping: "none",
-      showTitle: true,
-      colorPalette: "default",
-      colorMode: "palette",
-      stacked: false,
-      filters: [],
-      ...chart,
-      id: generateId(),
-      // The agent may return expression series without ids; the builder and
-      // renderer key each series by id, so ensure every one has a stable one.
-      ...(chart.series
-        ? { series: chart.series.map((s) => ({ ...s, id: s.id || generateId() })) }
-        : {}),
-    }));
+    return suggestions.map(withChartDefaults);
+  };
+
+  const handleCopiedCharts = (charts: ChartConfig[], summary: CopySummary) => {
+    chartCreatorRef.current?.appendCharts(charts);
+    trackCustomReportAction(TrackedCustomReportAction.COPY_CHARTS, summary);
+    notification.success({
+      message: `${charts.length} gráfico(s) copiados. Salve para gravar as alterações.`,
+    });
   };
 
   const executeDownloadWithFormat = (
@@ -391,6 +384,15 @@ export function FileReport() {
                               onChartsChange={setCurrentCharts}
                               readOnly={!canWriteGraphs}
                               onGenerateCharts={requestChartSuggestions}
+                              extraActions={
+                                <Button
+                                  icon={<CopyOutlined />}
+                                  onClick={() => setShowCopyCharts(true)}
+                                  disabled={schema.length === 0}
+                                >
+                                  Copiar de outro relatório
+                                </Button>
+                              }
                             />
 
                             {canWriteGraphs && (
@@ -525,6 +527,16 @@ export function FileReport() {
             onClick={handleSaveCharts}
           />
         </>
+      )}
+      {canWriteGraphs && (
+        <CopyCharts
+          open={showCopyCharts}
+          onClose={() => setShowCopyCharts(false)}
+          targetSchema={schema}
+          existingTitles={currentCharts.map((chart) => chart.title)}
+          currentSchemaName={currentSchema}
+          onImport={handleCopiedCharts}
+        />
       )}
       <FloatButton.BackTop
         style={{ right: 80, bottom: 25 }}

--- a/src/features/reports/ReportsSlice.js
+++ b/src/features/reports/ReportsSlice.js
@@ -98,6 +98,35 @@ export const suggestReportGraphs = createAsyncThunk(
   },
 );
 
+export const getCopySourceReports = createAsyncThunk(
+  "reports/custom/copy-source-list",
+  async (params, thunkAPI) => {
+    try {
+      const response = await api.custom.getCopySourceReports(
+        params.sourceSchema,
+      );
+      return response;
+    } catch (err) {
+      return thunkAPI.rejectWithValue(err.response.data);
+    }
+  },
+);
+
+export const getCopySourceGraphs = createAsyncThunk(
+  "reports/custom/copy-source-graphs",
+  async (params, thunkAPI) => {
+    try {
+      const response = await api.custom.getCopySourceGraphs(
+        params.idReport,
+        params.sourceSchema,
+      );
+      return response;
+    } catch (err) {
+      return thunkAPI.rejectWithValue(err.response.data);
+    }
+  },
+);
+
 export const getFileReport = createAsyncThunk(
   "reports/file-report",
   async (params, thunkAPI) => {

--- a/src/services/reports/api.js
+++ b/src/services/reports/api.js
@@ -89,6 +89,19 @@ api.custom.updateReportGraphs = (idReport, graphs) =>
 api.custom.suggestReportGraphs = (params = {}) =>
   instance.post(`/reports/custom/suggest-graphs`, params, setHeaders());
 
+// sourceSchema is optional: when omitted the sources come from the current schema
+api.custom.getCopySourceReports = (sourceSchema) =>
+  instance.get(`/admin/report/copy-source/list`, {
+    params: { sourceSchema },
+    ...setHeaders(),
+  });
+
+api.custom.getCopySourceGraphs = (idReport, sourceSchema) =>
+  instance.get(`/admin/report/copy-source/${idReport}/graphs`, {
+    params: { sourceSchema },
+    ...setHeaders(),
+  });
+
 // REGULATION
 api.regulation = {};
 api.regulation.getIndicatorsPanel = (params = {}) =>

--- a/src/utils/tracker.ts
+++ b/src/utils/tracker.ts
@@ -191,6 +191,7 @@ export enum TrackedCustomReportAction {
   ADD_FILTER = "add-filter",
   REMOVE_FILTER = "remove-filter",
   CLEAR_FILTERS = "clear-filters",
+  COPY_CHARTS = "copy-charts",
 }
 
 export enum TrackedPrescriptionPrioritizationAction {

--- a/tests/mocked/reports/copyCharts.spec.ts
+++ b/tests/mocked/reports/copyCharts.spec.ts
@@ -1,0 +1,327 @@
+import { gzipSync } from "node:zlib";
+
+import { test, expect, API_URL } from "../support/mockApi";
+import { loginWithPermissions } from "../support/featureLogin";
+import { loadFixture } from "../support/defaultHandlers";
+import { openSelect, pickOption } from "../support/antd";
+
+/**
+ * Copying charts from another custom report, including the column
+ * reconciliation the copy needs when the source chart names a column the
+ * destination report does not have.
+ *
+ * The destination dataset is served gzipped from the mocked API host, the same
+ * way the app consumes the presigned cache URL.
+ */
+
+const BASE_PERMISSIONS = [
+  "READ_BASIC_FEATURES",
+  "READ_PRESCRIPTION",
+  "READ_REPORTS",
+  "READ_CUSTOM_REPORTS",
+  "WRITE_CUSTOM_REPORTS_GRAPHS",
+];
+
+const REPORT_URL = "/relatorios/arquivo/CUSTOM/7/20260101";
+const CACHE_URL = `${API_URL}/cache/report.json.gz`;
+
+// The destination report has "setor" but not "unidade": the source chart below
+// names "unidade", which is what forces the reconciliation step.
+const DESTINATION_ROWS = [
+  { setor: "UTI", leito: "A1", dose: 10 },
+  { setor: "ENF", leito: "B2", dose: 20 },
+];
+
+const SOURCE_CHART = {
+  id: "src-1",
+  type: "bar",
+  xKeys: ["unidade"],
+  yKeys: ["__count__"],
+  title: "Prescrições por unidade",
+  width: "half",
+  aggregation: "count",
+};
+
+const PORTABLE_CHART = {
+  id: "src-2",
+  type: "pie",
+  xKeys: ["setor"],
+  yKeys: ["__count__"],
+  title: "Prescrições por setor",
+  width: "half",
+  aggregation: "count",
+};
+
+const ok = (data: unknown) => ({ json: { status: "success", data } });
+
+const installReportHandlers = (
+  mockApi: {
+    override: (key: string, handler: any) => void;
+  },
+  options: { sourceCharts?: unknown[]; ownCharts?: unknown[] } = {},
+) => {
+  mockApi.override(
+    "GET /reports/general/CUSTOM",
+    ok({
+      cached: true,
+      title: "Prescricoes com intervencao de subdose",
+      url: CACHE_URL,
+      graphs: JSON.stringify(options.ownCharts ?? []),
+    }),
+  );
+
+  // the gzipped dataset the app decompresses client-side
+  mockApi.override("GET /cache/report.json.gz", (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/octet-stream",
+      body: gzipSync(Buffer.from(JSON.stringify(DESTINATION_ROWS))),
+    }),
+  );
+
+  mockApi.override(
+    "GET /switch-schema",
+    ok({
+      maintainer: true,
+      schemas: [{ name: "demo" }, { name: "celiodecastro" }],
+    }),
+  );
+
+  mockApi.override(
+    "GET /admin/report/copy-source/list",
+    ok([
+      {
+        id: 42,
+        name: "Prescricoes com intervencao de subdose",
+        description: "origem",
+        status: 3,
+        processedAt: "2026-01-01T10:00:00",
+        graphCount: (options.sourceCharts ?? [SOURCE_CHART]).length,
+      },
+    ]),
+  );
+
+  mockApi.override(
+    "GET /admin/report/copy-source/:id/graphs",
+    ok({
+      id: 42,
+      name: "Prescricoes com intervencao de subdose",
+      sourceSchema: "celiodecastro",
+      graphs: options.sourceCharts ?? [SOURCE_CHART],
+    }),
+  );
+
+  mockApi.override("PATCH /admin/report/:id/graphs", ok({ id: 7 }));
+};
+
+const openCopyWizard = async (page: any) => {
+  await page.goto(REPORT_URL);
+
+  await expect(
+    page.getByRole("button", { name: "Copiar de outro relatório" }),
+  ).toBeEnabled({ timeout: 15000 });
+
+  await page.getByRole("button", { name: "Copiar de outro relatório" }).click();
+
+  return page.getByRole("dialog");
+};
+
+/**
+ * A maintainer lands on the schema chooser instead of the app, so the login
+ * helper cannot be reused: the schema has to be confirmed before the report
+ * page is reachable.
+ */
+const loginAsMaintainer = async (page: any, mockApi: any) => {
+  const auth = loadFixture<Record<string, unknown>>("auth/authenticate.json");
+  const payload = {
+    ...auth,
+    permissions: [...BASE_PERMISSIONS, "MULTI_SCHEMA", "MAINTAINER"],
+  };
+
+  mockApi.override("POST /authenticate", { json: payload });
+  mockApi.override("POST /switch-schema", { json: { status: "success", data: payload } });
+
+  await page.goto("/login");
+  await page.getByPlaceholder("Email").fill("e2e@noharm.ai");
+  await page.getByPlaceholder("Senha").fill("mocked-password");
+  await page.getByRole("button", { name: "Acessar" }).click();
+
+  await page.getByRole("button", { name: "Definir schema" }).click();
+
+  await expect(page.getByText("E2E Test")).toBeVisible({ timeout: 15000 });
+  await page.waitForTimeout(1000);
+};
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("copies a chart whose columns all exist in the destination", async ({
+  page,
+  mockApi,
+}) => {
+  installReportHandlers(mockApi, { sourceCharts: [PORTABLE_CHART] });
+  await loginWithPermissions(page, mockApi, BASE_PERMISSIONS);
+
+  const dialog = await openCopyWizard(page);
+
+  await openSelect(dialog.getByTestId("copy-source-report"));
+  await pickOption(page, "Prescricoes com intervencao de subdose");
+
+  await dialog.getByRole("button", { name: "Próximo" }).click();
+
+  // nothing to reconcile
+  await expect(
+    dialog.getByText(
+      "Todas as colunas usadas pelos gráficos existem neste relatório.",
+    ),
+  ).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Próximo" }).click();
+  await dialog.getByRole("button", { name: /Copiar 1 gráfico/ }).click();
+
+  await expect(page.getByText("Alterações não salvas")).toBeVisible();
+
+  // the copied chart reaches the save payload with a fresh id
+  await page.getByRole("button", { name: "save", exact: true }).click();
+  await expect(page.getByText("Gráficos salvos com sucesso.")).toBeVisible();
+
+  const saved = mockApi.requests.find(
+    (request) => request.method === "PATCH" && request.path.endsWith("/graphs"),
+  );
+  const charts = JSON.parse(JSON.parse(saved!.postData!).graphs);
+
+  expect(charts).toHaveLength(1);
+  expect(charts[0].title).toBe("Prescrições por setor");
+  expect(charts[0].xKeys).toEqual(["setor"]);
+  expect(charts[0].id).not.toBe(PORTABLE_CHART.id);
+});
+
+test("maps a column that does not exist in the destination", async ({
+  page,
+  mockApi,
+}) => {
+  installReportHandlers(mockApi);
+  await loginAsMaintainer(page, mockApi);
+
+  const dialog = await openCopyWizard(page);
+
+  // a maintainer picks the source schema
+  await openSelect(dialog.getByTestId("copy-source-schema"));
+  await pickOption(page, "celiodecastro");
+
+  await openSelect(dialog.getByTestId("copy-source-report"));
+  await pickOption(page, "Prescricoes com intervencao de subdose");
+
+  await dialog.getByRole("button", { name: "Próximo" }).click();
+
+  // the missing column blocks the copy until it is mapped
+  await expect(
+    dialog.getByRole("cell", { name: "unidade", exact: true }),
+  ).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Próximo" })).toBeDisabled();
+
+  await openSelect(dialog.locator(".ant-table tbody tr").first());
+  await pickOption(page, "setor (string)");
+
+  await expect(dialog.getByText("Pronto")).toBeVisible();
+  await dialog.getByRole("button", { name: "Próximo" }).click();
+  await dialog.getByRole("button", { name: /Copiar 1 gráfico/ }).click();
+
+  await page.getByRole("button", { name: "save", exact: true }).click();
+  await expect(page.getByText("Gráficos salvos com sucesso.")).toBeVisible();
+
+  const saved = mockApi.requests.find(
+    (request) => request.method === "PATCH" && request.path.endsWith("/graphs"),
+  );
+  const charts = JSON.parse(JSON.parse(saved!.postData!).graphs);
+
+  expect(charts[0].xKeys).toEqual(["setor"]);
+
+  // the source schema travelled on the copy-source requests
+  const listCall = mockApi.requests.find((request) =>
+    request.path.endsWith("/copy-source/list"),
+  );
+  expect(listCall).toBeTruthy();
+});
+
+test("ignoring a column leaves the affected chart out of the copy", async ({
+  page,
+  mockApi,
+}) => {
+  installReportHandlers(mockApi, {
+    sourceCharts: [SOURCE_CHART, PORTABLE_CHART],
+  });
+  await loginWithPermissions(page, mockApi, BASE_PERMISSIONS);
+
+  const dialog = await openCopyWizard(page);
+
+  await openSelect(dialog.getByTestId("copy-source-report"));
+  await pickOption(page, "Prescricoes com intervencao de subdose");
+
+  await dialog.getByRole("button", { name: "Próximo" }).click();
+
+  await openSelect(dialog.locator(".ant-table tbody tr").first());
+  await pickOption(page, "Ignorar (remove os gráficos afetados)");
+
+  await dialog.getByRole("button", { name: "Próximo" }).click();
+  await dialog.getByRole("button", { name: /Copiar 1 gráfico/ }).click();
+
+  await page.getByRole("button", { name: "save", exact: true }).click();
+  await expect(page.getByText("Gráficos salvos com sucesso.")).toBeVisible();
+
+  const saved = mockApi.requests.find(
+    (request) => request.method === "PATCH" && request.path.endsWith("/graphs"),
+  );
+  const charts = JSON.parse(JSON.parse(saved!.postData!).graphs);
+
+  expect(charts).toHaveLength(1);
+  expect(charts[0].title).toBe("Prescrições por setor");
+});
+
+test("a user without MAINTAINER cannot choose another schema", async ({
+  page,
+  mockApi,
+}) => {
+  installReportHandlers(mockApi);
+  await loginWithPermissions(page, mockApi, BASE_PERMISSIONS);
+
+  const dialog = await openCopyWizard(page);
+
+  await expect(dialog.getByText("Schema de origem")).toHaveCount(0);
+  await expect(dialog.getByText("Relatório de origem")).toBeVisible();
+
+  // no schema list is even requested
+  expect(
+    mockApi.requests.filter((request) => request.path === "/switch-schema"),
+  ).toEqual([]);
+});
+
+test("a duplicated title is copied with a suffix", async ({
+  page,
+  mockApi,
+}) => {
+  installReportHandlers(mockApi, {
+    sourceCharts: [PORTABLE_CHART],
+    ownCharts: [{ ...PORTABLE_CHART, id: "own-1" }],
+  });
+  await loginWithPermissions(page, mockApi, BASE_PERMISSIONS);
+
+  const dialog = await openCopyWizard(page);
+
+  await openSelect(dialog.getByTestId("copy-source-report"));
+  await pickOption(page, "Prescricoes com intervencao de subdose");
+
+  await dialog.getByRole("button", { name: "Próximo" }).click();
+  await dialog.getByRole("button", { name: "Próximo" }).click();
+  await dialog.getByRole("button", { name: /Copiar 1 gráfico/ }).click();
+
+  await page.getByRole("button", { name: "save", exact: true }).click();
+  await expect(page.getByText("Gráficos salvos com sucesso.")).toBeVisible();
+
+  const saved = mockApi.requests.find(
+    (request) => request.method === "PATCH" && request.path.endsWith("/graphs"),
+  );
+  const charts = JSON.parse(JSON.parse(saved!.postData!).graphs);
+
+  expect(charts).toHaveLength(2);
+  expect(charts[1].title).toBe("Prescrições por setor (cópia)");
+});


### PR DESCRIPTION
Permite copiar os gráficos de outro relatório customizado — inclusive de **outro schema** — para dentro do relatório aberto, com conciliação das colunas que os gráficos referenciam.

Depende de noharm-ai/backend#651 (endpoints de leitura da origem).

## O fluxo

No editor de gráficos surge o botão **"Copiar de outro relatório"**, que abre um wizard de três passos:

1. **Origem** — schema (só para mantenedores) e relatório de origem
2. **Colunas** — as colunas que não existem no relatório destino, cada uma apontável para uma coluna equivalente ou marcável como ignorada; a lista de gráficos mostra o estado de cada um (pronto / aguardando mapeamento / fora da cópia)
3. **Revisão** — o que será importado

Os gráficos são **anexados** aos existentes (nunca substituem) via `chartCreatorRef.appendCharts`, o indicador de "Alterações não salvas" acende e o usuário grava pelo botão de salvar de sempre. O fluxo de salvamento não mudou.

## A conciliação (`src/components/ChartCreator/chartRemap.ts`)

Um gráfico referencia colunas em cinco lugares, e todos são tratados: `xKeys`, `yKeys` (a sentinela `__count__` passa intacta), `filters[].field`, as colunas dentro das expressões das séries, e as chaves de `seriesColors`.

A reescrita das expressões usa o round-trip de tokens do `exprEngine` (`exprToTokens` → troca `token.column` → `tokensToExpr`), **não** substituição de texto. Isso importa porque o `quoteColumn` re-aplica as aspas na serialização, então uma coluna com espaço (`soma("dose diaria")`) sobrevive. Depois o resultado ainda passa por `validateExpr` contra o schema destino.

A cópia também descarta deliberadamente o que não viaja entre relatórios:

- **`categoryColors`** — chaveadas por valores do dataset de origem, que nada dizem sobre o destino
- **valores de filtro** que a coluna destino não possui — um filtro sem valor válido esconderia todas as linhas, então ele é removido
- **ids** de gráfico e de série são regerados, e as chaves de cor seguem o mapeamento

Títulos duplicados ganham sufixo `(cópia)`, `(cópia 2)`…

Um gráfico é deixado de fora quando perde uma coluna sem a qual não existe: expressão que não faz parse, coluna de expressão ignorada, ou eixo X vazio. O tipo **medidor** é exceção — não tem eixo X por definição (é o que o `dataValid` do `ChartWizard` já assumia), e havia um bug meu descartando todos eles; está corrigido em commit próprio.

## Refactor de apoio

O bloco de defaults que o `FileReport` aplicava aos gráficos sugeridos pelo agente virou `withChartDefaults` no `chartRemap.ts`, agora compartilhado pelos dois caminhos (sugestão e cópia). Comportamento idêntico.

## Segurança

O seletor de schema de origem só aparece para quem tem `Permission.MAINTAINER`, espelhando o que o backend autoriza. Sem essa permissão, `sourceSchema` nem é enviado e o backend resolve para o schema do próprio usuário. A autorização de verdade é toda no backend — o gate do frontend é usabilidade, não barreira.

## Testes

`tests/mocked/reports/copyCharts.spec.ts`, 5 cenários que vão até o payload do `PATCH`:

- cópia same-schema quando todas as colunas existem
- cross-schema como mantenedor, com uma coluna mapeada — asserta o `xKeys` remapeado no payload salvo
- ignorar uma coluna deixa o gráfico afetado de fora
- usuário sem MAINTAINER não vê o seletor de schema (e o `switch-schema` nem é chamado)
- título duplicado ganha o sufixo `(cópia)`

Suíte mockada completa: 52 testes passando. `tsc` e `eslint` sem erros novos.

A lógica pura do `chartRemap` foi validada à parte em 28 checagens (round-trip de expressão com coluna entre aspas, interseção de valores de filtro, chaves de cor, medidor sem eixo X, títulos), e foi assim que o bug do medidor apareceu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)